### PR TITLE
Make startAce take a reference to its parent

### DIFF
--- a/src/Reflex/Dom/ACE.hs
+++ b/src/Reflex/Dom/ACE.hs
@@ -129,8 +129,7 @@ instance Show AceTheme where
     show AceTheme_Xcode = "xcode"
 
 data AceConfig = AceConfig
-    { _aceConfigElemId    :: Text
-    , _aceConfigElemAttrs :: Map Text Text
+    { _aceConfigElemAttrs :: Map Text Text
     , _aceConfigBasePath  :: Maybe Text
     , _aceConfigMode      :: Maybe Text
     }
@@ -143,6 +142,7 @@ instance Default AceConfig where
     def = AceConfig "editor" def def def
 
 #ifndef ghcjs_HOST_OS
+data Element = Element
 data JSVal = JSVal
 jsNull :: JSVal
 jsNull = JSVal
@@ -152,6 +152,7 @@ jsval = const JSVal
 
 toJSString :: a -> b
 toJSString _ = undefined
+
 #endif
 
 newtype AceRef = AceRef { unAceRef :: JSVal }
@@ -310,7 +311,7 @@ aceWidget ac adc adcUps initContents = do
     withAceRef ace (setThemeACE . _aceDynConfigTheme <$> adcUps)
     return ace
   where
-    static = "id" =: _aceConfigElemId ac <> _aceConfigElemAttrs ac
+    static = _aceConfigElemAttrs ac
     themeAttr t = " ace-" <> T.pack (show t)
     addThemeAttr c = maybe static
       (\t -> M.insertWith (<>) "class" (themeAttr t) static)
@@ -339,8 +340,3 @@ withAceRef'
     -> m (Event t a)
 withAceRef' ace val =
     performEvent $ attachPromptlyDynWith (flip ($)) (aceRef ace) val
-
-
-#ifndef ghcjs_HOST_OS
-data Element = Element
-#endif

--- a/src/Reflex/Dom/ACE.hs
+++ b/src/Reflex/Dom/ACE.hs
@@ -139,7 +139,7 @@ data AceDynConfig = AceDynConfig
     }
 
 instance Default AceConfig where
-    def = AceConfig "editor" def def def
+    def = AceConfig def def def
 
 #ifndef ghcjs_HOST_OS
 data Element = Element

--- a/src/Reflex/Dom/ACE.hs
+++ b/src/Reflex/Dom/ACE.hs
@@ -169,7 +169,6 @@ startACE :: Element -> AceConfig -> IO AceRef
 #ifdef ghcjs_HOST_OS
 startACE elmt ac =
     js_startACE (pToJSVal elmt)
-                -- (toJSString $ _aceConfigElemId ac)
                 (mtext2val $ _aceConfigBasePath ac)
                 (mtext2val $ _aceConfigMode ac)
 


### PR DESCRIPTION
This fixes a race condition that was causing `startACE` to fail under some new ghcjs versions.

Previously, it was possible for `startACE` to try to build the ace editor before its parent div was constructed. Calling `startACE` with a reference to that element instead of an id tag forces the correct order.