### PR TITLE
Makes exe buildable: False

### DIFF
--- a/reflex-dom-ace.cabal
+++ b/reflex-dom-ace.cabal
@@ -33,6 +33,7 @@ library
   default-language: Haskell2010
 
 executable reflex-dom-ace-exe
+  buildable:           False
   hs-source-dirs:      app
   main-is:             Main.hs
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N


### PR DESCRIPTION
This fixes a bug where downstream projects' compilation is broken because of building this exe.